### PR TITLE
feat: text 컴포넌트 구현

### DIFF
--- a/packages/design-system/Text.stories.tsx
+++ b/packages/design-system/Text.stories.tsx
@@ -1,18 +1,59 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Text } from "./Text";
 
-const meta: Meta = {
-  title: "ds/Text",
+const meta = {
+  title: "Components/Text",
+  component: Text,
+  parameters: {
+    layout: "centered",
+  },
   tags: ["autodocs"],
-};
-export default meta;
+} satisfies Meta<typeof Text>;
 
-export const Default: StoryObj = {
-  render: () => {
-    return (
-      <>
-        <Text className=" text-purple-100">hello</Text>
-      </>
-    );
+export default meta;
+type Story = StoryObj<typeof Text>;
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Text variant="title/25_b">Title 25 Bold - The quick brown fox</Text>
+      <Text variant="title/25_sb">Title 25 SemiBold - The quick brown fox</Text>
+      <Text variant="title/25_m">Title 25 Medium - The quick brown fox</Text>
+      <Text variant="title/24_sb">Title 24 SemiBold - The quick brown fox</Text>
+      <Text variant="title/24_m">Title 24 Medium - The quick brown fox</Text>
+      <Text variant="title/20_b">Title 20 Bold - The quick brown fox</Text>
+      <Text variant="title/20_sb">Title 20 SemiBold - The quick brown fox</Text>
+      <Text variant="title/16_b">Title 16 Bold - The quick brown fox</Text>
+      <Text variant="title/16_sb">Title 16 SemiBold - The quick brown fox</Text>
+      <Text variant="title/16_m">Title 16 Medium - The quick brown fox</Text>
+      <Text variant="title/14_sb">Title 14 SemiBold - The quick brown fox</Text>
+      <Text variant="title/14_m">Title 14 Medium - The quick brown fox</Text>
+      <Text variant="title/12_sb">Title 12 SemiBold - The quick brown fox</Text>
+      <Text variant="title/12_m">Title 12 Medium - The quick brown fox</Text>
+      <Text variant="title/12_r">Title 12 Regular - The quick brown fox</Text>
+    </div>
+  ),
+};
+
+export const SingleVariant: Story = {
+  args: {
+    variant: "title/25_b",
+    children: "Title 25 Bold Text",
+  },
+};
+
+export const CustomClassName: Story = {
+  args: {
+    variant: "title/20_sb",
+    className: "text-blue-500 italic",
+    children: "Custom Styled Text",
+  },
+};
+
+export const AsHeading: Story = {
+  args: {
+    variant: "title/25_b",
+    as: "h1",
+    children: "This is a heading",
   },
 };

--- a/packages/design-system/Text.tsx
+++ b/packages/design-system/Text.tsx
@@ -4,17 +4,30 @@ import { type VariantProps, cva } from "class-variance-authority";
 import { type ElementType, forwardRef } from "react";
 import { cn } from "./cn";
 
-export const textVariants = cva("", {
+export const textVariants = cva("leading-[150%] tracking-[-2%]", {
   variants: {
     variant: {
-      title25b: "",
+      "title/25_b": "font-bold text-[25px]",
+      "title/25_sb": "font-semibold text-[25px]",
+      "title/25_m": "font-medium text-[25px]",
+      "title/24_sb": "font-semibold text-[24px]",
+      "title/24_m": "font-medium text-[24px]",
+      "title/20_b": "font-bold text-[20px]",
+      "title/20_sb": "font-semibold text-[20px]",
+      "title/16_b": "font-bold text-[16px]",
+      "title/16_sb": "font-semibold text-[16px]",
+      "title/16_m": "font-medium text-[16px]",
+      "title/14_sb": "font-semibold text-[14px]",
+      "title/14_m": "font-medium text-[14px]",
+      "title/12_sb": "font-semibold text-[12px]",
+      "title/12_m": "font-medium text-[12px]",
+      "title/12_r": "font-normal text-[12px]",
     },
   },
 });
-
 type TextProps = VariantProps<typeof textVariants>;
 
-export const Text = forwardRef(function Text<C extends ElementType = "div">(
+export const Text = forwardRef(function Text<C extends ElementType = "span">(
   { as, className, variant, ...rest }: BoxProps<C> & TextProps,
   ref?: BoxRef<C>,
 ) {


### PR DESCRIPTION

<img width="603" alt="Screenshot 2025-01-07 at 19 55 30" src="https://github.com/user-attachments/assets/968b9538-5787-4873-bf38-7aa9ed4e55ef" />

디자인 시스템의 Text 컴포넌트 구현하였습니다.

우선 [] 문법을 통해 하드 코딩하였습니다.