### PR TITLE
feat: search bar implement

### DIFF
--- a/packages/design-system/SearchBar.stories.tsx
+++ b/packages/design-system/SearchBar.stories.tsx
@@ -1,0 +1,39 @@
+import { MagnifyIcon } from "@repo/icon/MagnifyIcon";
+import type { Meta, StoryObj } from "@storybook/react";
+import { SearchBar } from "./SearchBar";
+
+const meta: Meta = {
+  title: "ds/SearchBar",
+  tags: ["autodocs"],
+};
+export default meta;
+
+export const WithoutIcon: StoryObj = {
+  render: () => {
+    return (
+      <>
+        <SearchBar placeholder="책 제목을 검색해주세요" />
+      </>
+    );
+  },
+};
+
+export const WithIcon: StoryObj = {
+  render: () => {
+    return (
+      <>
+        <SearchBar placeholder="책 제목을 검색해주세요" left={<MagnifyIcon />} />
+      </>
+    );
+  },
+};
+
+export const WithIconAndValue: StoryObj = {
+  render: () => {
+    return (
+      <>
+        <SearchBar placeholder="책 제목을 검색해주세요" value={"hello"} left={<MagnifyIcon />} />
+      </>
+    );
+  },
+};

--- a/packages/design-system/SearchBar.tsx
+++ b/packages/design-system/SearchBar.tsx
@@ -1,0 +1,36 @@
+import { type ComponentPropsWithoutRef, type Ref, forwardRef } from "react";
+import { cn } from "./cn";
+
+interface SearchBarProps extends ComponentPropsWithoutRef<"input"> {
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+export const SearchBar = forwardRef(function SearchBar(
+  { children, className, left, right, ...rest }: SearchBarProps,
+  ref?: Ref<HTMLInputElement>,
+) {
+  return (
+    <div className=" w-full relative">
+      <div className=" absolute top-[50%] translate-y-[-50%] translate-x-[14px] max-w-[24px] max-h-[24px]  overflow-clip flex justify-center items-center ">
+        {left}
+      </div>
+      <input
+        ref={ref}
+        className={cn(
+          "text-[18px]",
+          // bg-gray-100 placeholder:text-gray-300
+          " rounded-[12px] bg-[#F5F5F9] placeholder:text-[#C6C6CF] ",
+          "  pt-[12px] pb-[9px] w-full duration-200 transition-colors focus:outline-none",
+          left ? " pl-[50px] " : " pl-[12px] ",
+          // text body/18_m
+          className,
+        )}
+        {...rest}
+      />
+      <div className=" absolute top-[50%] translate-y-[-50%] right-0 translate-x-[-14px] max-w-[24px] max-h-[24px]  overflow-clip flex justify-center items-center ">
+        {right}
+      </div>
+    </div>
+  );
+});

--- a/packages/icon/MagnifyIcon.tsx
+++ b/packages/icon/MagnifyIcon.tsx
@@ -1,0 +1,13 @@
+export const MagnifyIcon = () => {
+  return (
+    // biome-ignore lint/a11y/noSvgWithoutTitle: <explanation>
+    <svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M17 17.5L21 21.5" stroke="#C6C6CF" strokeWidth="2.3" strokeLinecap="round" />
+      <path
+        d="M11.0429 19.5181C15.4109 19.5181 18.9518 15.9772 18.9518 11.6092C18.9518 7.24129 15.4109 3.70038 11.0429 3.70038C6.675 3.70038 3.13409 7.24129 3.13409 11.6092C3.13409 15.9772 6.675 19.5181 11.0429 19.5181Z"
+        stroke="#C6C6CF"
+        strokeWidth="2.5"
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION
<img width="934" alt="Screenshot 2025-01-07 at 20 30 28" src="https://github.com/user-attachments/assets/8bf04e4f-7675-4be7-aa23-5f7c912f60fa" />

아직 포커스 상태일떄, disabled 상태일떄의 시안을 전달받지 못하여 해당 부분 공란으로 남겨두었습니다.