### PR TITLE
feat: add storage 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@use-funnel/browser": "^0.0.10",
         "@webview-bridge/web": "^1.7.5",
         "@xionwcfm/react": "^0.1.1",
+        "@xionwcfm/storage": "^0.0.7",
         "@xionwcfm/utils": "^0.0.3",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.5.2",
@@ -4726,6 +4727,12 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/@xionwcfm/storage": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@xionwcfm/storage/-/storage-0.0.7.tgz",
+      "integrity": "sha512-zHKFeSRHnasdpmS/fbb+cFzpFTJiLU1/QTkMj8U1vEDPLL5ENHzcuLMkLoVHFhGT1AQH/q5B5yyLg1Tlvb1wug==",
+      "license": "MIT"
     },
     "node_modules/@xionwcfm/utils": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@use-funnel/browser": "^0.0.10",
     "@webview-bridge/web": "^1.7.5",
     "@xionwcfm/react": "^0.1.1",
+    "@xionwcfm/storage": "^0.0.7",
     "@xionwcfm/utils": "^0.0.3",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.5.2",

--- a/packages/storage/localStorageService.ts
+++ b/packages/storage/localStorageService.ts
@@ -1,0 +1,3 @@
+import { StorageService } from "@xionwcfm/storage";
+
+export const LocalStorageService = new StorageService(window.localStorage);

--- a/packages/storage/useLocalStorageService.ts
+++ b/packages/storage/useLocalStorageService.ts
@@ -1,0 +1,6 @@
+import { LocalStorageService } from "./localStorageService";
+import { type OmitStorageServiceOptions, useStorageService } from "./useStorageService";
+export const useLocalStorageService = <T>(key: string, options: OmitStorageServiceOptions<T>) => {
+  const storage = LocalStorageService;
+  return useStorageService(key, { ...options, storage });
+};

--- a/packages/storage/useStorageService.ts
+++ b/packages/storage/useStorageService.ts
@@ -1,0 +1,37 @@
+import type { StorageService } from "@xionwcfm/storage";
+import { useSyncExternalStore } from "react";
+import { useCallback } from "react";
+
+export interface StorageServiceOptions<T> {
+  storage: StorageService;
+  defaultValue: T;
+}
+
+export type OmitStorageServiceOptions<T> = Omit<StorageServiceOptions<T>, "storage">;
+
+export const useStorageService = <T>(
+  key: string,
+  options: StorageServiceOptions<T> | StorageServiceOptions<T>,
+) => {
+  const storage = options.storage;
+  const setStorage = useCallback(
+    (newValue: string) => {
+      storage.setItem(key, newValue);
+      dispatchEvent(new StorageEvent("storage", { key: key, newValue }));
+    },
+    [key, storage],
+  );
+
+  const getSnapshot = () => storage.getItem(key) ?? options.defaultValue;
+
+  const subscribe = (listener: () => void) => {
+    window.addEventListener("storage", listener);
+    return () => window.removeEventListener("storage", listener);
+  };
+
+  const getServerSnapshot = () => options.defaultValue;
+
+  const store = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot) as T;
+
+  return [store, setStorage] as const;
+};


### PR DESCRIPTION

로컬 스토리지, 세션 스토리지 관리를 체계적으로 할 수 있도록 인터페이스를 구성했습니다.

인터페이스는 대체로 window.localStorage와 동일합니다.

```ts
const result = LocalStorageService.getItem<T>('key') // T | null
const useLocalStorageService('key', {defaultValue:"hello"}) // string | null
```